### PR TITLE
liblzma: Optimize to include `mythread.h` only where necessary.

### DIFF
--- a/src/liblzma/common/common.h
+++ b/src/liblzma/common/common.h
@@ -14,7 +14,6 @@
 #define LZMA_COMMON_H
 
 #include "sysdefs.h"
-#include "mythread.h"
 #include "tuklib_integer.h"
 
 #if defined(_WIN32) || defined(__CYGWIN__)

--- a/src/liblzma/common/stream_decoder_mt.c
+++ b/src/liblzma/common/stream_decoder_mt.c
@@ -11,6 +11,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "mythread.h"
 #include "common.h"
 #include "block_decoder.h"
 #include "stream_decoder.h"

--- a/src/liblzma/common/stream_encoder_mt.c
+++ b/src/liblzma/common/stream_encoder_mt.c
@@ -10,6 +10,7 @@
 //
 ///////////////////////////////////////////////////////////////////////////////
 
+#include "mythread.h"
 #include "filter_encoder.h"
 #include "easy_preset.h"
 #include "block_encoder.h"


### PR DESCRIPTION
この変更によりliblzmaはthread=OFFを指定した際に、WebAssemblyをターゲットにしたコンパイルが容易になります。

これまで`liblzma/commom/common.h`がインクルードされていたことにより利用できた、`common/mythread.h`に含まれていた宣言がなくなります。

この変更は、liblzmaの公開APIを利用しているユーザーに直接影響はありませんが、非公開APIを利用している一部のユーザーにとって破壊的変更になります。

非公開APIなので過敏になる必要はないかもしれません