### PR TITLE
liblzma: disable signal functions in builds targeting wasm

### DIFF
--- a/src/common/mythread.h
+++ b/src/common/mythread.h
@@ -79,7 +79,7 @@ do { \
 } while (0)
 
 
-#if !(defined(_WIN32) && !defined(__CYGWIN__))
+#if !((defined(_WIN32) && !defined(__CYGWIN__)) || defined(__wasm__))
 // Use sigprocmask() to set the signal mask in single-threaded programs.
 #include <signal.h>
 


### PR DESCRIPTION

Thanks for the review #xx yesterday!

I tried another approach, could you please review this one?

Changed to exclude signal functions not supported by WebAssembly using the predefined `__wasm__` macro when the build target is set to wasm32 with clang.
This change allows `liblzma` to be built with the platform-independent `wasm32-uknown-unknown` target.

I believe this exclusion will work in the same way as the build when targeting Windows, so it will minimize unexpected changes.

If you need, you can see the predefined macros when targeting wasm32 in clang by following commands
```
clang -E -dM -target wasm32-unknown-unknown -x c /dev/null
```
or if you want to check with the latest wasi-sdk clang
```sh
docker image pull ghcr.io/webassembly/wasi-sdk
docker run --rm -i ghcr.io/webassembly/wasi-sdk clang-16 -E -dM -target wasm32-unknown-unknown -x c /dev/null
```
